### PR TITLE
Fix für Wandsprünge

### DIFF
--- a/Platformer_001/Assets/Scripts/PlayerMovementController.cs
+++ b/Platformer_001/Assets/Scripts/PlayerMovementController.cs
@@ -41,7 +41,7 @@ public class PlayerMovementController : MonoBehaviour {
 		if (Input.GetKey(KeyCode.D)) Bewegen(Richtung.RECHTS);
         if (Input.GetKey(KeyCode.A)) Bewegen(Richtung.LINKS);
 
-        bool amBoden = col.IsTouchingLayers();
+        bool amBoden = rb.velocity.y < 0.001f && rb.velocity.y > -0.001f;
         anim.SetBool("jump", !amBoden);
 
         if (Input.GetKeyDown(KeyCode.W) && (amBoden || doubleJump)) {


### PR DESCRIPTION
Es ist möglich, unendlich oft zu springen, wenn man an eine Wand gelehnt ist. Das liegt daran, dass `IsTouchingLayers()` auch bei horizontaler Kollision `true` ist.

Ich habe das Problem gelöst, indem ich Sprünge nur erlaube, wenn die vertikale Geschwindigkeit des Spielers 0 ist.