### PR TITLE
Kein Sprungangriff

### DIFF
--- a/Platformer_001/Assets/Scripts/ItemController.cs
+++ b/Platformer_001/Assets/Scripts/ItemController.cs
@@ -81,6 +81,8 @@ public class ItemController : MonoBehaviour {
     }
 
     public void Angreifen() {
+		var pmc = GetComponent<PlayerMovementController>();
+		if (pmc != null && !pmc.IstAmBoden ()) return;
         if (itemInHand == null) return;
         
         anim.SetTrigger(string.Format("attack-{0}", itemInHand.name));

--- a/Platformer_001/Assets/Scripts/PlayerMovementController.cs
+++ b/Platformer_001/Assets/Scripts/PlayerMovementController.cs
@@ -36,11 +36,15 @@ public class PlayerMovementController : MonoBehaviour {
         this.richtung = richtung < 0.0f ? Richtung.LINKS : Richtung.RECHTS;
         rb.velocity = new Vector2(richtung * speed, rb.velocity.y);
     }
-	
+
+	public bool IstAmBoden() {
+		return rb.velocity.y < 0.001f && rb.velocity.y > -0.001f;
+	}
+
 	void Update() {
         Bewegen(Input.GetAxis("Horizontal"));
 
-        bool amBoden = rb.velocity.y < 0.001f && rb.velocity.y > -0.001f;
+		bool amBoden = IstAmBoden();
         anim.SetBool("jump", !amBoden);
 
         if (Input.GetButtonDown("Jump") && (amBoden || doubleJump)) {


### PR DESCRIPTION
Verhindert (vorrübergehend), dass der Spieler sich die Schulter auskugelt beim springen + angreifen.