### PR TITLE
Fix für Hintergrund-Flackern

### DIFF
--- a/Platformer_001/Assets/Scripts/PositionFollower.cs
+++ b/Platformer_001/Assets/Scripts/PositionFollower.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -16,9 +17,13 @@ public class PositionFollower : MonoBehaviour {
 	// Update is called once per frame
 	void Update ()
 	{
-		Vector3 a = new Vector3 (parent.transform.position.x, transform.position.y, -10f);
-		Vector3 b = new Vector3 (parent.transform.position.x, parent.transform.position.y + 2, -10f);
-		transform.position = Vector3.Slerp (a, b, Time.deltaTime*2);
-
+		var a = new Vector3 (parent.transform.position.x, transform.position.y, -10f);
+		var b = new Vector3 (parent.transform.position.x, parent.transform.position.y + 2, -10f);
+		transform.position = Vector3.Slerp(a, b, Time.deltaTime*2);
+		transform.position = new Vector3 (
+			(float)Math.Round (transform.position.x, 3),
+			(float)Math.Round (transform.position.y, 3),
+			(float)Math.Round (transform.position.z, 3)
+		);
 	}
 }


### PR DESCRIPTION
In der Schule sah es zwar okay aus, aber bei mir zu Hause am PC flackert der Hintergrund stark wenn man sich bewegt. Das liegt daran, dass `float`s nicht sehr präzise sind. Ich habe es behoben, indem ich die Kameraposition auf 2 Stellen gerundet habe.